### PR TITLE
Missing dependency: libwnck-3-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The following are technical details for developers who want to manually compile 
 
 * elementary-sdk
 * libclutter-1.0-dev
+* libwnck-3-dev
 
 Make sure you `apt install` all of the above requirements before trying to build.
 


### PR DESCRIPTION
Couldn't get it to build without `libwnck-3-dev` (and cmake, but that one is kind of expected)